### PR TITLE
Add support of any language

### DIFF
--- a/src/Search.ts
+++ b/src/Search.ts
@@ -70,7 +70,7 @@ export class QuoteModal extends Modal {
     this.plugin = plugin
     this.index = 5 // The initial number of sentences to display for a quote
     // Split the incoming text into sentences
-    this.sentences = [...text.matchAll(/.+?[.?!\n]['"’”]?\s+(?=[“‘"']?[A-Z])/sg)].map(x => x[0])
+    this.sentences = [...text.matchAll(/.+?[.?!\n]['"’”]?\s+(?=[“‘"']?\p{Lu})/sgu)].map(x => x[0])
   }
 
   async onOpen () {


### PR DESCRIPTION
Regex used for splitting text into sentences was meant to match only english letters, i've changed regex for supporting any languages uppercase letter. You can read about it more [here](https://www.regular-expressions.info/unicode.html#:~:text=%5Cp%7BLu%7D%20or%20%5Cp%7BUppercase_Letter%7D%3A%20an%20uppercase%20letter%20that%20has%20a%20lowercase%20variant.). fixes #4